### PR TITLE
Catch all exceptions that occur during request processing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>net.sympower</groupId>
 	<artifactId>jamod</artifactId>
 	<packaging>jar</packaging>
-	<version>1.2.3-2-SNAPSHOT</version>
+	<version>1.2.3-2</version>
 	<name>jamod</name>
 	<url>http://jamod.sourceforge.net</url>
 	<description>

--- a/src/main/java/net/wimpi/modbus/Modbus.java
+++ b/src/main/java/net/wimpi/modbus/Modbus.java
@@ -143,6 +143,13 @@ public interface Modbus {
     public static final int ILLEGAL_VALUE_EXCEPTION = 3;
 
     /**
+     * Defines the Modbus slave exception type <tt>slave device failure</tt>.
+     * This exception code indicates that a fault occurred in the slave device while
+     * processing the request.
+     */
+    public static final int SLAVE_DEVICE_FAILURE = 4;
+
+    /**
      * Defines the default port number of Modbus
      * (=<tt>502</tt>).
      */

--- a/src/main/java/net/wimpi/modbus/msg/ExceptionResponse.java
+++ b/src/main/java/net/wimpi/modbus/msg/ExceptionResponse.java
@@ -91,4 +91,10 @@ public class ExceptionResponse extends ModbusResponse {
         m_ExceptionCode = din.readUnsignedByte();
     }// readData
 
+    @Override
+    protected void appendFieldsToString(StringBuilder sb) {
+        super.appendFieldsToString(sb);
+        sb.append(", exceptionCode=").append(m_ExceptionCode);
+    }
+
 }// ExceptionResponse

--- a/src/main/java/net/wimpi/modbus/msg/ModbusMessageImpl.java
+++ b/src/main/java/net/wimpi/modbus/msg/ModbusMessageImpl.java
@@ -240,4 +240,20 @@ public abstract class ModbusMessageImpl implements ModbusMessage {
         return ModbusUtil.toHex(this);
     }// getHexMessage
 
+    protected void appendFieldsToString(StringBuilder sb) {
+        sb.append("transactionID=").append(m_TransactionID);
+        sb.append(", protocolID=").append(m_ProtocolID);
+        sb.append(", dataLength=").append(m_DataLength);
+        sb.append(", unitID=").append(m_UnitID);
+        sb.append(", functionCode=").append(m_FunctionCode);
+        sb.append(", headless=").append(m_Headless);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder(256);
+        sb.append(getClass().getSimpleName()).append(": ");
+        appendFieldsToString(sb);
+        return sb.toString();
+    }
 }// class ModbusMessageImpl

--- a/src/main/java/net/wimpi/modbus/msg/ReadCoilsRequest.java
+++ b/src/main/java/net/wimpi/modbus/msg/ReadCoilsRequest.java
@@ -168,4 +168,11 @@ public final class ReadCoilsRequest extends ModbusRequest {
         m_BitCount = din.readUnsignedShort();
     }// readData
 
+    @Override
+    protected void appendFieldsToString(StringBuilder sb) {
+        super.appendFieldsToString(sb);
+        sb.append(", reference=").append(m_Reference);
+        sb.append(", bitCount=").append(m_BitCount);
+    }
+
 }// class ReadCoilsRequest

--- a/src/main/java/net/wimpi/modbus/msg/ReadCoilsResponse.java
+++ b/src/main/java/net/wimpi/modbus/msg/ReadCoilsResponse.java
@@ -137,4 +137,10 @@ public final class ReadCoilsResponse extends ModbusResponse {
         setDataLength(count + 1);
     }// readData
 
+    @Override
+    protected void appendFieldsToString(StringBuilder sb) {
+        super.appendFieldsToString(sb);
+        sb.append(", coils=").append(m_Coils);
+    }
+
 }// class ReadCoilsResponse

--- a/src/main/java/net/wimpi/modbus/msg/ReadInputDiscretesRequest.java
+++ b/src/main/java/net/wimpi/modbus/msg/ReadInputDiscretesRequest.java
@@ -176,6 +176,13 @@ public final class ReadInputDiscretesRequest extends ModbusRequest {
         m_BitCount = din.readUnsignedShort();
     }// readData
 
+    @Override
+    protected void appendFieldsToString(StringBuilder sb) {
+        super.appendFieldsToString(sb);
+        sb.append(", reference=").append(m_Reference);
+        sb.append(", bitCount=").append(m_BitCount);
+    }
+
     /*
      * protected void assembleData() throws IOException {
      * m_DataOut.writeShort(m_Reference);

--- a/src/main/java/net/wimpi/modbus/msg/ReadInputDiscretesResponse.java
+++ b/src/main/java/net/wimpi/modbus/msg/ReadInputDiscretesResponse.java
@@ -149,4 +149,11 @@ public final class ReadInputDiscretesResponse extends ModbusResponse {
         setDataLength(count + 1);
     }// readData
 
+    @Override
+    protected void appendFieldsToString(StringBuilder sb) {
+        super.appendFieldsToString(sb);
+        sb.append(", bitCount=").append(m_BitCount);
+        sb.append(", discretes=").append(m_Discretes);
+    }
+
 }// class ReadInputDiscretesResponse

--- a/src/main/java/net/wimpi/modbus/msg/ReadInputRegistersRequest.java
+++ b/src/main/java/net/wimpi/modbus/msg/ReadInputRegistersRequest.java
@@ -159,4 +159,11 @@ public final class ReadInputRegistersRequest extends ModbusRequest {
         m_WordCount = din.readUnsignedShort();
     }// readData
 
+    @Override
+    protected void appendFieldsToString(StringBuilder sb) {
+        super.appendFieldsToString(sb);
+        sb.append(", reference=").append(m_Reference);
+        sb.append(", wordCount=").append(m_WordCount);
+    }
+
 }// class ReadInputRegistersRequest

--- a/src/main/java/net/wimpi/modbus/msg/ReadInputRegistersResponse.java
+++ b/src/main/java/net/wimpi/modbus/msg/ReadInputRegistersResponse.java
@@ -178,7 +178,7 @@ public final class ReadInputRegistersResponse extends ModbusResponse {
     protected void appendFieldsToString(StringBuilder sb) {
         super.appendFieldsToString(sb);
         sb.append(", byteCount=").append(m_ByteCount);
-        sb.append(", registers=").append(Arrays.asList(m_Registers));
+        sb.append(", registers=").append(Arrays.toString(m_Registers));
     }
 
 }// class ReadInputRegistersResponse

--- a/src/main/java/net/wimpi/modbus/msg/ReadInputRegistersResponse.java
+++ b/src/main/java/net/wimpi/modbus/msg/ReadInputRegistersResponse.java
@@ -19,6 +19,7 @@ package net.wimpi.modbus.msg;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Arrays;
 
 import net.wimpi.modbus.Modbus;
 import net.wimpi.modbus.ModbusCoupler;
@@ -172,5 +173,12 @@ public final class ReadInputRegistersResponse extends ModbusResponse {
         // update data length
         setDataLength(getByteCount() + 1);
     }// readData
+
+    @Override
+    protected void appendFieldsToString(StringBuilder sb) {
+        super.appendFieldsToString(sb);
+        sb.append(", byteCount=").append(m_ByteCount);
+        sb.append(", registers=").append(Arrays.asList(m_Registers));
+    }
 
 }// class ReadInputRegistersResponse

--- a/src/main/java/net/wimpi/modbus/msg/ReadMultipleRegistersRequest.java
+++ b/src/main/java/net/wimpi/modbus/msg/ReadMultipleRegistersRequest.java
@@ -159,4 +159,11 @@ public final class ReadMultipleRegistersRequest extends ModbusRequest {
         m_WordCount = din.readUnsignedShort();
     }// readData
 
+    @Override
+    protected void appendFieldsToString(StringBuilder sb) {
+        super.appendFieldsToString(sb);
+        sb.append(", reference=").append(m_Reference);
+        sb.append(", wordCount=").append(m_WordCount);
+    }
+
 }// class ReadMultipleRegistersRequest

--- a/src/main/java/net/wimpi/modbus/msg/ReadMultipleRegistersResponse.java
+++ b/src/main/java/net/wimpi/modbus/msg/ReadMultipleRegistersResponse.java
@@ -177,7 +177,7 @@ public final class ReadMultipleRegistersResponse extends ModbusResponse {
     protected void appendFieldsToString(StringBuilder sb) {
         super.appendFieldsToString(sb);
         sb.append(", byteCount=").append(m_ByteCount);
-        sb.append(", registers=").append(Arrays.asList(m_Registers));
+        sb.append(", registers=").append(Arrays.toString(m_Registers));
     }
 
 }// class ReadMultipleRegistersResponse

--- a/src/main/java/net/wimpi/modbus/msg/ReadMultipleRegistersResponse.java
+++ b/src/main/java/net/wimpi/modbus/msg/ReadMultipleRegistersResponse.java
@@ -19,6 +19,7 @@ package net.wimpi.modbus.msg;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Arrays;
 
 import net.wimpi.modbus.Modbus;
 import net.wimpi.modbus.ModbusCoupler;
@@ -171,5 +172,12 @@ public final class ReadMultipleRegistersResponse extends ModbusResponse {
         // update data length
         setDataLength(getByteCount() + 1);
     }// readData
+
+    @Override
+    protected void appendFieldsToString(StringBuilder sb) {
+        super.appendFieldsToString(sb);
+        sb.append(", byteCount=").append(m_ByteCount);
+        sb.append(", registers=").append(Arrays.asList(m_Registers));
+    }
 
 }// class ReadMultipleRegistersResponse

--- a/src/main/java/net/wimpi/modbus/msg/WriteCoilRequest.java
+++ b/src/main/java/net/wimpi/modbus/msg/WriteCoilRequest.java
@@ -173,4 +173,11 @@ public final class WriteCoilRequest extends ModbusRequest {
         din.readByte();
     }// readData
 
+    @Override
+    protected void appendFieldsToString(StringBuilder sb) {
+        super.appendFieldsToString(sb);
+        sb.append(", reference=").append(m_Reference);
+        sb.append(", coil=").append(m_Coil);
+    }
+
 }// class WriteCoilRequest

--- a/src/main/java/net/wimpi/modbus/msg/WriteCoilResponse.java
+++ b/src/main/java/net/wimpi/modbus/msg/WriteCoilResponse.java
@@ -137,4 +137,11 @@ public final class WriteCoilResponse extends ModbusResponse {
         setDataLength(4);
     }// readData
 
+    @Override
+    protected void appendFieldsToString(StringBuilder sb) {
+        super.appendFieldsToString(sb);
+        sb.append(", reference=").append(m_Reference);
+        sb.append(", coil=").append(m_Coil);
+    }
+
 }// class WriteCoilResponse

--- a/src/main/java/net/wimpi/modbus/msg/WriteMultipleCoilsRequest.java
+++ b/src/main/java/net/wimpi/modbus/msg/WriteMultipleCoilsRequest.java
@@ -237,4 +237,11 @@ public final class WriteMultipleCoilsRequest extends ModbusRequest {
         setDataLength(count + 5);
     }// readData
 
+    @Override
+    protected void appendFieldsToString(StringBuilder sb) {
+        super.appendFieldsToString(sb);
+        sb.append(", reference=").append(m_Reference);
+        sb.append(", coils=").append(m_Coils);
+    }
+
 }// class WriteMultipleCoilsRequest

--- a/src/main/java/net/wimpi/modbus/msg/WriteMultipleCoilsResponse.java
+++ b/src/main/java/net/wimpi/modbus/msg/WriteMultipleCoilsResponse.java
@@ -113,4 +113,11 @@ public final class WriteMultipleCoilsResponse extends ModbusResponse {
         m_BitCount = din.readUnsignedShort();
     }// readData
 
+    @Override
+    protected void appendFieldsToString(StringBuilder sb) {
+        super.appendFieldsToString(sb);
+        sb.append(", reference=").append(m_Reference);
+        sb.append(", bitCount=").append(m_BitCount);
+    }
+
 }// class ReadCoilsResponse

--- a/src/main/java/net/wimpi/modbus/msg/WriteMultipleRegistersRequest.java
+++ b/src/main/java/net/wimpi/modbus/msg/WriteMultipleRegistersRequest.java
@@ -19,6 +19,7 @@ package net.wimpi.modbus.msg;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Arrays;
 
 import net.wimpi.modbus.Modbus;
 import net.wimpi.modbus.ModbusCoupler;
@@ -277,5 +278,12 @@ public final class WriteMultipleRegistersRequest extends ModbusRequest {
             m_NonWordDataHandler.readData(din, m_Reference, wc);
         }
     }// readData
+
+    @Override
+    protected void appendFieldsToString(StringBuilder sb) {
+        super.appendFieldsToString(sb);
+        sb.append(", reference=").append(m_Reference);
+        sb.append(", registers=").append(Arrays.toString(m_Registers));
+    }
 
 }// class WriteMultipleRegistersRequest

--- a/src/main/java/net/wimpi/modbus/msg/WriteMultipleRegistersResponse.java
+++ b/src/main/java/net/wimpi/modbus/msg/WriteMultipleRegistersResponse.java
@@ -133,4 +133,11 @@ public final class WriteMultipleRegistersResponse extends ModbusResponse {
         setDataLength(4);
     }// readData
 
+    @Override
+    protected void appendFieldsToString(StringBuilder sb) {
+        super.appendFieldsToString(sb);
+        sb.append(", reference=").append(m_Reference);
+        sb.append(", wordCount=").append(m_WordCount);
+    }
+
 }// class WriteMultipleRegistersResponse

--- a/src/main/java/net/wimpi/modbus/msg/WriteSingleRegisterRequest.java
+++ b/src/main/java/net/wimpi/modbus/msg/WriteSingleRegisterRequest.java
@@ -159,4 +159,11 @@ public final class WriteSingleRegisterRequest extends ModbusRequest {
                 din.readByte());
     }// readData
 
+    @Override
+    protected void appendFieldsToString(StringBuilder sb) {
+        super.appendFieldsToString(sb);
+        sb.append(", reference=").append(m_Reference);
+        sb.append(", register=").append(m_Register);
+    }
+
 }// class WriteSingleRegisterRequest

--- a/src/main/java/net/wimpi/modbus/msg/WriteSingleRegisterResponse.java
+++ b/src/main/java/net/wimpi/modbus/msg/WriteSingleRegisterResponse.java
@@ -132,4 +132,11 @@ public final class WriteSingleRegisterResponse extends ModbusResponse {
      * }//readData
      */
 
+    @Override
+    protected void appendFieldsToString(StringBuilder sb) {
+        super.appendFieldsToString(sb);
+        sb.append(", reference=").append(m_Reference);
+        sb.append(", registerValue=").append(m_RegisterValue);
+    }
+
 }// class WriteSingleRegisterResponse

--- a/src/main/java/net/wimpi/modbus/net/TCPConnectionHandler.java
+++ b/src/main/java/net/wimpi/modbus/net/TCPConnectionHandler.java
@@ -70,7 +70,13 @@ public class TCPConnectionHandler implements Runnable {
                 if (ModbusCoupler.getReference().getProcessImage() == null) {
                     response = request.createExceptionResponse(Modbus.ILLEGAL_FUNCTION_EXCEPTION);
                 } else {
-                    response = request.createResponse();
+                    try {
+                        response = request.createResponse();
+                    }
+                    catch (Exception e) {
+                        logger.error("Error while processing request", e);
+                        response = request.createExceptionResponse(Modbus.SLAVE_DEVICE_FAILURE);
+                    }
                 }
                 logger.debug("Request (transaction id {}): {}", request.getTransactionID(), request.getHexMessage());
                 logger.debug("Response (transaction id {}): {}", response.getTransactionID(), response.getHexMessage());
@@ -80,13 +86,13 @@ public class TCPConnectionHandler implements Runnable {
         } catch (ModbusIOException ex) {
             if (!ex.isEOF()) {
                 // other troubles, output for debug
-                ex.printStackTrace();
+                logger.debug("IO error while processing request", ex);
             }
         } finally {
             try {
                 m_Connection.close();
             } catch (Exception ex) {
-                // ignore
+                logger.trace("Error while closing connection", ex);
             }
 
         }

--- a/src/main/java/net/wimpi/modbus/net/TCPConnectionHandler.java
+++ b/src/main/java/net/wimpi/modbus/net/TCPConnectionHandler.java
@@ -65,6 +65,7 @@ public class TCPConnectionHandler implements Runnable {
                 // 1. read the request
                 ModbusRequest request = m_Transport.readRequest();
                 ModbusResponse response = null;
+                logger.debug("Request (transaction id {}): {}", request.getTransactionID(), request.getHexMessage());
 
                 // test if Process image exists
                 if (ModbusCoupler.getReference().getProcessImage() == null) {
@@ -74,13 +75,12 @@ public class TCPConnectionHandler implements Runnable {
                         response = request.createResponse();
                     }
                     catch (Exception e) {
-                        logger.error("Error while processing request", e);
+                        logger.error("Error while processing request {}", request, e);
                         response = request.createExceptionResponse(Modbus.SLAVE_DEVICE_FAILURE);
                     }
                 }
-                logger.debug("Request (transaction id {}): {}", request.getTransactionID(), request.getHexMessage());
-                logger.debug("Response (transaction id {}): {}", response.getTransactionID(), response.getHexMessage());
 
+                logger.debug("Response (transaction id {}): {}", response.getTransactionID(), response.getHexMessage());
                 m_Transport.writeMessage(response);
             } while (true);
         } catch (ModbusIOException ex) {

--- a/src/main/java/net/wimpi/modbus/procimg/AbstractRegister.java
+++ b/src/main/java/net/wimpi/modbus/procimg/AbstractRegister.java
@@ -71,4 +71,9 @@ public abstract class AbstractRegister implements Register {
         }
     }// setValue
 
+    @Override
+    public String toString() {
+        return String.valueOf(getValue());
+    }
+
 }// class AbstractRegister

--- a/src/main/java/net/wimpi/modbus/procimg/SynchronizedAbstractRegister.java
+++ b/src/main/java/net/wimpi/modbus/procimg/SynchronizedAbstractRegister.java
@@ -75,4 +75,9 @@ public abstract class SynchronizedAbstractRegister implements Register {
         return m_Register;
     }// toBytes
 
+    @Override
+    public String toString() {
+        return String.valueOf(getValue());
+    }
+
 }// class SynchronizedAbstractRegister


### PR DESCRIPTION
Catch all exceptions that occur during request processing and send back "slave device failure" error. Also improved other error handling in the same method.