### PR TITLE
patch: update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.7</maven.compiler.source>
-		<maven.compiler.target>1.7</maven.compiler.target>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.7</version>
+				<version>2.10.4</version>
 				<configuration>
 					<additionalOptions>-html5</additionalOptions>
 					<show>private</show>

--- a/pom.xml
+++ b/pom.xml
@@ -54,19 +54,19 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j.micro</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.22-8</version>
+			<version>1.7.22-14</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.2</version>
+			<version>2.17.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -83,7 +83,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>2.1.2</version>
+				<version>3.1.0</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>
@@ -96,13 +96,14 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
-				<version>2.7</version>
+				<version>3.1.0</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.10.4</version>
+				<version>2.7</version>
 				<configuration>
+					<additionalOptions>-html5</additionalOptions>
 					<show>private</show>
 					<nohelp>true</nohelp>
 				</configuration>
@@ -121,7 +122,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.7.0</version>
+				<version>3.10.1</version>
 				<configuration>
 					<source>${maven.compiler.source}</source>
 					<target>${maven.compiler.target}</target>
@@ -130,7 +131,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.20.1</version>
+				<version>2.22.2</version>
 				<configuration>
 					<forkCount>2C</forkCount>
 					<reuseForks>true</reuseForks>
@@ -143,14 +144,14 @@
 					<dependency>
 						<groupId>org.apache.maven.surefire</groupId>
 						<artifactId>surefire-junit4</artifactId>
-						<version>2.20.1</version>
+						<version>2.22.2</version>
 					</dependency>
 				</dependencies>
 			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.4.0</version>
 				<executions>
 					<execution>
 						<phase>initialize</phase>
@@ -203,7 +204,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-project-info-reports-plugin</artifactId>
-				<version>2.4</version>
+				<version>3.0.0</version>
 				<reportSets>
 					<reportSet>
 						<reports>
@@ -220,7 +221,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.10.4</version>
+				<version>3.1.1</version>
 				<configuration>
 					<show>public</show>
 				</configuration>

--- a/src/main/java/net/wimpi/modbus/io/ModbusTransport.java
+++ b/src/main/java/net/wimpi/modbus/io/ModbusTransport.java
@@ -44,7 +44,7 @@ public interface ModbusTransport {
     public void close() throws IOException;
 
     /**
-     * Writes a <tt<ModbusMessage</tt> to the
+     * Writes a <tt>ModbusMessage</tt> to the
      * output stream of this <tt>ModbusTransport</tt>.
      * <p>
      *


### PR DESCRIPTION
# Description

There are several [dependabot vulnerabilitie](https://github.com/sympower/jamod/security/dependabot)s that we need to address.

This PR updates all dependencies to a newer version. Hopefully this give us a bit time.
Eventually [we will replace jamod](https://sympower.atlassian.net/browse/CONN-767) with [sympower-modbus](https://github.com/sympower/sympower-modbus), but that might take a while.


Note to the reviewer:

A) `org.apache.maven.plugings:maven-javadoc-plugin` is only update to 2.7.
   In theory it could go to 3.1.1 but the `<additionalOptions>-html5</additionalOptions>` configuration option does not work.

B) In IntelliJ I get the following error:

```
jamod build failed
  ModbusTCPTransport.jav
java: cannot access java.util.stream.Stream
  class file for java.util.stream.Stream not found
```

When I run 'mvn package' I get the following error: * This is obsolete after the bumb to java 8
```
[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] Source option 7 is no longer supported. Use 8 or later.
[ERROR] Target option 7 is no longer supported. Use 8 or later.
[INFO] 2 errors
```



## Type of change

- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Refactor
- [ ] Documentation update
